### PR TITLE
Fix left and right capture logic

### DIFF
--- a/Chessboard.gd
+++ b/Chessboard.gd
@@ -170,14 +170,14 @@ func get_valid_moves(piece) -> Array:
 		if is_valid_square(leftCapture):
 			var leftCapturePiece = get_piece_on_square(leftCapture)
 			var lcpColor = leftCapturePiece.to_lower()==leftCapturePiece
-			if leftCapturePiece != null and lcpColor != is_black:
+			if leftCapturePiece != ' ' and lcpColor != is_black:
 				validMoves.append(leftCapture)
 				
 		# Check if right capture is valid
 		if is_valid_square(rightCapture):
 			var rightCapturePiece = get_piece_on_square(rightCapture)
 			var rcpColor = rightCapturePiece.to_lower()==rightCapturePiece
-			if rightCapturePiece != null and rcpColor != is_black:
+			if rightCapturePiece != ' ' and rcpColor != is_black:
 				validMoves.append(rightCapture)
 		
 		# Check for valid moves one square forward


### PR DESCRIPTION
Issue was not from double moving, rather a null check instead of a blank square check.

**Before**
![image](https://user-images.githubusercontent.com/37484165/232130538-dd994bd7-f266-4769-88fd-e8d34e775ee9.png)
_White piece able to left and right capture on blank tiles_

**After**
![image](https://user-images.githubusercontent.com/37484165/232130741-b5c66485-0578-4ffe-ae43-a71b66bd31d2.png)
_White piece unable to left and right capture on blank tiles_