### PR TITLE
When deselecting a piece set the lastPiece to null

### DIFF
--- a/Chessboard.gd
+++ b/Chessboard.gd
@@ -100,6 +100,7 @@ func _input(event: InputEvent) -> void:
 				# ... add your logic here ...
 			else:
 				set_selected_piece()
+				lastPiece=null
 
 func _process(delta: float) -> void:
 	if selectedPiece != null:


### PR DESCRIPTION
# Fixes #16

## Before:
Selecting a piece then deselecting it by clicking an empty square results in the piece being unable to be selected again

## After:
Selecting a piece then deselecting it by clicking an empty square results in the lastPiece being set to null which allows the piece to be selected again
