### PR TITLE
Change z index of piece sprites

### DIFF
--- a/Chessboard.gd
+++ b/Chessboard.gd
@@ -52,6 +52,7 @@ func _ready() -> void:
 				else:
 					pieceSprite.texture = load("res://sprites/" + pieceChar + "1.png")
 				pieceSprite.position = Vector2(col, row) * cellSize - myOffset
+				pieceSprite.z_index = 1
 				pieceSprite.scale = Vector2(cellSize.x / pieceSprite.texture.get_width(), cellSize.y / pieceSprite.texture.get_height())
 				add_child(pieceSprite)
 


### PR DESCRIPTION
# Fixes #19 

## Before:
![image](https://user-images.githubusercontent.com/37484165/232167011-3e33f5f6-7e28-4395-8f5c-02e7db66a766.png)
_Highlighted tiles are in front of piece sprites_

## After:
![image](https://user-images.githubusercontent.com/37484165/232166971-b65121be-e884-4d63-8101-b1167e777720.png)
_Highlighted tiles are behind piece sprites_